### PR TITLE
Proposal : Create empty local config file for Docker compose.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 node_modules
 coverage/
 
-*.local.*
 data.json
 
 lib-cov

--- a/.npmignore
+++ b/.npmignore
@@ -2,5 +2,3 @@
 
 .git*
 .npmignore
-
-*.local.*

--- a/config.local.js
+++ b/config.local.js
@@ -1,0 +1,4 @@
+'use strict';
+module.exports =
+{
+};

--- a/docker-compose.debug.yml
+++ b/docker-compose.debug.yml
@@ -1,19 +1,21 @@
-lodex:
-  image: node:4.4.0
-  links:
-    - lodex_db:mongodb
-  volumes:
-    - .:/app
-  environment:
-    http_proxy:  ${http_proxy}
-    https_proxy: ${https_proxy}
-    NODE_ENV: "development"
-    DEBUG: "castor*,console*"
-  working_dir: /app
-  ports:
-    - 3000:3000
-  command: ./lodex
+version: '2'
+services:
+  lodex:
+    image: node:4.4.0
+    links:
+      - lodex_db:mongodb
+    volumes:
+      - .:/app
+    environment:
+      http_proxy:  ${http_proxy}
+      https_proxy: ${https_proxy}
+      NODE_ENV: "development"
+      DEBUG: "castor*,console*"
+   working_dir: /app
+    ports:
+      - 3000:3000
+    command: ./lodex
 
-lodex_db:
-  image: mongo:3.0.7
-  command: --smallfiles
+  lodex_db:
+    image: mongo:3.0.7
+    command: --smallfiles

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,19 +1,21 @@
-lodex:
-  image: node:4.4.0
-  links:
-    - lodex_db:mongodb
-  volumes:
-    - .:/app
-  environment:
-    http_proxy:  ${http_proxy}
-    https_proxy: ${https_proxy}
-    NODE_ENV: "development"
-    DEBUG: "castor*,console*"
-  working_dir: /app
-  ports:
-    - 3000:3000
-  command: ./node_modules/.bin/nodemon ./lodex
+version: '2'
+services:
+  lodex:
+    image: node:4.4.0
+    links:
+      - lodex_db:mongodb
+    volumes:
+      - .:/app
+    environment:
+      http_proxy:  ${http_proxy}
+      https_proxy: ${https_proxy}
+      NODE_ENV: "development"
+      DEBUG: "castor*,console*"
+    working_dir: /app
+    ports:
+      - 3000:3000
+    command: ./node_modules/.bin/nodemon ./lodex
 
-lodex_db:
-  image: mongo:3.0.7
-  command: --smallfiles
+  lodex_db:
+    image: mongo:3.0.7
+    command: --smallfiles

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,17 +1,19 @@
-lodex:
-  image: inistcnrs/lodex:latest
-  links:
-    - lodex_db:mongodb
-  volumes:
-    - ./data:/app/data
-    - ./config.local.js:/app/config.local.js
-  environment:
-    http_proxy:  ${http_proxy}
-    https_proxy: ${https_proxy}
-    NODE_ENV: ${NODE_ENV}
-  ports:
-    - 3000:3000
+version: '2'
+services:
+  lodex:
+    image: inistcnrs/lodex:latest
+    links:
+      - lodex_db:mongodb
+    volumes:
+      - ./data:/app/data
+      - ./config.local.js:/app/config.local.js
+    environment:
+      http_proxy:  ${http_proxy}
+      https_proxy: ${https_proxy}
+      NODE_ENV: ${NODE_ENV}
+    ports:
+      - 3000:3000
 
-lodex_db:
-  image: mongo:3.0.7
-  command: --smallfiles
+  lodex_db:
+    image: mongo:3.0.7
+    command: --smallfiles


### PR DESCRIPTION
Hi,

If you not set default config.local.js (with empty configuration).

Docker compose declare this volume as a folder (see docker-composer.yml in your root project).

As a result, if you run docker-composer up and try to create config.local.js, the process will failed.

Regards.