### PR TITLE
Proposal : Upgrade to Docker Compose version 2

### DIFF
--- a/docker-compose.debug.yml
+++ b/docker-compose.debug.yml
@@ -1,19 +1,21 @@
-lodex:
-  image: node:4.4.0
-  links:
-    - lodex_db:mongodb
-  volumes:
-    - .:/app
-  environment:
-    http_proxy:  ${http_proxy}
-    https_proxy: ${https_proxy}
-    NODE_ENV: "development"
-    DEBUG: "castor*,console*"
-  working_dir: /app
-  ports:
-    - 3000:3000
-  command: ./lodex
+version: '2'
+services:
+  lodex:
+    image: node:4.4.0
+    links:
+      - lodex_db:mongodb
+    volumes:
+      - .:/app
+    environment:
+      http_proxy:  ${http_proxy}
+      https_proxy: ${https_proxy}
+      NODE_ENV: "development"
+      DEBUG: "castor*,console*"
+   working_dir: /app
+    ports:
+      - 3000:3000
+    command: ./lodex
 
-lodex_db:
-  image: mongo:3.0.7
-  command: --smallfiles
+  lodex_db:
+    image: mongo:3.0.7
+    command: --smallfiles

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,19 +1,21 @@
-lodex:
-  image: node:4.4.0
-  links:
-    - lodex_db:mongodb
-  volumes:
-    - .:/app
-  environment:
-    http_proxy:  ${http_proxy}
-    https_proxy: ${https_proxy}
-    NODE_ENV: "development"
-    DEBUG: "castor*,console*"
-  working_dir: /app
-  ports:
-    - 3000:3000
-  command: ./node_modules/.bin/nodemon ./lodex
+version: '2'
+services:
+  lodex:
+    image: node:4.4.0
+    links:
+      - lodex_db:mongodb
+    volumes:
+      - .:/app
+    environment:
+      http_proxy:  ${http_proxy}
+      https_proxy: ${https_proxy}
+      NODE_ENV: "development"
+      DEBUG: "castor*,console*"
+    working_dir: /app
+    ports:
+      - 3000:3000
+    command: ./node_modules/.bin/nodemon ./lodex
 
-lodex_db:
-  image: mongo:3.0.7
-  command: --smallfiles
+  lodex_db:
+    image: mongo:3.0.7
+    command: --smallfiles

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,17 +1,19 @@
-lodex:
-  image: inistcnrs/lodex:latest
-  links:
-    - lodex_db:mongodb
-  volumes:
-    - ./data:/app/data
-    - ./config.local.js:/app/config.local.js
-  environment:
-    http_proxy:  ${http_proxy}
-    https_proxy: ${https_proxy}
-    NODE_ENV: ${NODE_ENV}
-  ports:
-    - 3000:3000
+version: '2'
+services:
+  lodex:
+    image: inistcnrs/lodex:latest
+    links:
+      - lodex_db:mongodb
+    volumes:
+      - ./data:/app/data
+      - ./config.local.js:/app/config.local.js
+    environment:
+      http_proxy:  ${http_proxy}
+      https_proxy: ${https_proxy}
+      NODE_ENV: ${NODE_ENV}
+    ports:
+      - 3000:3000
 
-lodex_db:
-  image: mongo:3.0.7
-  command: --smallfiles
+  lodex_db:
+    image: mongo:3.0.7
+    command: --smallfiles


### PR DESCRIPTION
Version 1 will be deprecated in a future Compose release. Moving from version 1 to 2 is a very simple process:
- Indent the whole file by one level and put a services: key at the top.
- Add a version: '2' line at the top of the file.